### PR TITLE
Glog контроль логування

### DIFF
--- a/composite.go
+++ b/composite.go
@@ -146,8 +146,16 @@ func (c composite) Fatal(format string, a ...interface{}) {
 	}
 }
 
+func (c composite) SetLevel(logLevel LogLevel) {
+	for _, l := range c.chain {
+		if setter, ok := l.(LevelSetter); ok {
+			setter.SetLevel(logLevel)
+		}
+	}
+}
+
 func DefaultComposite(main Logger, loggers ...Logger) {
-	_default = Composite(main, loggers...)
+	setDefault(Composite(main, loggers...))
 }
 
 func Composite(main Logger, loggers ...Logger) Logger {

--- a/logger.go
+++ b/logger.go
@@ -2,8 +2,11 @@ package glog
 
 import (
 	"fmt"
+	"io"
 	"log"
 	"os"
+	"sync"
+	"sync/atomic"
 )
 
 type Output interface {
@@ -53,13 +56,106 @@ type Logger interface {
 	Fatal(format string, a ...interface{})
 }
 
-type logger struct {
-	logLevel LogLevel
-	out      *log.Logger
-	err      *log.Logger
-	fatalf   func(format string, a ...interface{})
+type LevelSetter interface {
+	SetLevel(logLevel LogLevel)
 }
 
+type LevelRouter interface {
+	Logger
+	SetOutputForLevel(logLevel LogLevel, out io.Writer)
+	SetOutputs(outputs map[LogLevel]io.Writer)
+}
+
+type logger struct {
+	level  *int32
+	out    *log.Logger
+	err    *log.Logger
+	fatalf func(format string, a ...interface{})
+	router *outputRouter
+}
+
+type outputRouter struct {
+	mu      sync.RWMutex
+	outputs map[LogLevel]Output
+}
+
+func newOutputRouter() *outputRouter {
+	return &outputRouter{
+		outputs: make(map[LogLevel]Output),
+	}
+}
+
+func (r *outputRouter) SetOutput(level LogLevel, out Output) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if out == nil {
+		delete(r.outputs, level)
+		return
+	}
+
+	r.outputs[level] = out
+}
+
+func (r *outputRouter) SetOutputs(outputs map[LogLevel]Output) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.outputs = make(map[LogLevel]Output, len(outputs))
+	for level, out := range outputs {
+		if out != nil {
+			r.outputs[level] = out
+		}
+	}
+}
+
+func (r *outputRouter) OutputFor(level LogLevel) (Output, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	out, ok := r.outputs[level]
+	return out, ok
+}
+
+type discardWriter struct{}
+
+func (discardWriter) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+var discardWriterInstance io.Writer = discardWriter{}
+
+func newLevelPointer(logLevel LogLevel) *int32 {
+	level := int32(logLevel.weight)
+	return &level
+}
+
+func newStdLogger(writer io.Writer) *log.Logger {
+	if writer == nil {
+		writer = discardWriterInstance
+	}
+	return log.New(writer, "", log.LstdFlags)
+}
+
+func outputFromWriter(writer io.Writer) Output {
+	if writer == nil {
+		return nil
+	}
+	return newStdLogger(writer)
+}
+
+func outputsFromWriters(outputs map[LogLevel]io.Writer) map[LogLevel]Output {
+	if len(outputs) == 0 {
+		return map[LogLevel]Output{}
+	}
+	converted := make(map[LogLevel]Output, len(outputs))
+	for level, writer := range outputs {
+		if writer != nil {
+			converted[level] = newStdLogger(writer)
+		}
+	}
+	return converted
+}
 func (l logger) IsDebug() bool {
 	return l.IsEnabled(DEBUG)
 }
@@ -81,15 +177,35 @@ func (l logger) IsError() bool {
 }
 
 func (l logger) IsEnabled(logLevel LogLevel) bool {
-	return logLevel.weight >= l.logLevel.weight
+	return int32(logLevel.weight) >= l.currentLevelWeight()
+}
+
+func (l logger) currentLevelWeight() int32 {
+	if l.level == nil {
+		return int32(INFO.weight)
+	}
+	return atomic.LoadInt32(l.level)
 }
 
 func create(logLevel LogLevel) logger {
 	return logger{
-		logLevel: logLevel,
-		err:      _stderr,
-		out:      _stdout,
-		fatalf:   _stderr.Fatalf,
+		level:  newLevelPointer(logLevel),
+		err:    _stderr,
+		out:    _stdout,
+		fatalf: _stderr.Fatalf,
+		router: newOutputRouter(),
+	}
+}
+
+func createWithWriters(out io.Writer, err io.Writer, logLevel LogLevel) logger {
+	outLogger := newStdLogger(out)
+	errLogger := newStdLogger(err)
+	return logger{
+		level:  newLevelPointer(logLevel),
+		err:    errLogger,
+		out:    outLogger,
+		fatalf: errLogger.Fatalf,
+		router: newOutputRouter(),
 	}
 }
 
@@ -99,14 +215,12 @@ func createFileLogger(file string, level ...LogLevel) (logger, error) {
 		logLevel = level[0]
 	}
 
-	var instance = logger{
-		logLevel: logLevel,
-	}
+	instance := create(logLevel)
 	openFile, err := os.OpenFile(file, os.O_CREATE|os.O_APPEND, 0644)
 	if err != nil {
-		return instance, _default.Error("Error creating file %s output: %s", file, err)
+		return instance, Error("Error creating file %s output: %s", file, err)
 	}
-	w := log.New(openFile, "", log.LstdFlags)
+	w := newStdLogger(openFile)
 	instance.err = w
 	instance.out = w
 	instance.fatalf = w.Fatalf
@@ -115,6 +229,20 @@ func createFileLogger(file string, level ...LogLevel) (logger, error) {
 
 func Create(logLevel LogLevel) Logger {
 	return create(logLevel)
+}
+
+func NewWithWriters(out io.Writer, err io.Writer, logLevel LogLevel) Logger {
+	return createWithWriters(out, err, logLevel)
+}
+
+func NewLevelRouter(outputs map[LogLevel]io.Writer, level ...LogLevel) LevelRouter {
+	logLevel := INFO
+	if len(level) > 0 {
+		logLevel = level[0]
+	}
+	instance := create(logLevel)
+	instance.SetOutputs(outputs)
+	return instance
 }
 
 var _stdout = log.New(os.Stdout, "", log.LstdFlags)
@@ -146,28 +274,77 @@ func (l logger) TraceLogger() Output {
 	return l.GetOutput(TRACE)
 }
 
+func (l logger) SetLevel(logLevel LogLevel) {
+	if l.level == nil {
+		return
+	}
+	atomic.StoreInt32(l.level, int32(logLevel.weight))
+}
+
+func (l logger) SetOutputForLevel(logLevel LogLevel, out io.Writer) {
+	if l.router == nil {
+		return
+	}
+	l.router.SetOutput(logLevel, outputFromWriter(out))
+}
+
+func (l logger) SetOutputs(outputs map[LogLevel]io.Writer) {
+	if l.router == nil {
+		return
+	}
+	l.router.SetOutputs(outputsFromWriters(outputs))
+}
+
 func (l logger) Log(logLevel LogLevel, format string, objs ...interface{}) {
 	logFormat := logLevel.prefix + " " + format
 
 	if logLevel == PANIC {
+		if out, ok := l.outputForLevel(logLevel); ok {
+			if panicOut, ok := out.(interface {
+				Panicf(format string, a ...interface{})
+			}); ok {
+				panicOut.Panicf(logFormat, objs...)
+				return
+			}
+		}
 		l.err.Panicf(logFormat, objs...)
 		return
 	}
 	if logLevel == FATAL {
+		if out, ok := l.outputForLevel(logLevel); ok {
+			if fatalOut, ok := out.(interface {
+				Fatalf(format string, a ...interface{})
+			}); ok {
+				fatalOut.Fatalf(logFormat, objs...)
+				return
+			}
+		}
 		l.fatalf(logFormat, objs...)
 		return
 	}
 
-	var out Output
-	if logLevel.weight < l.logLevel.weight {
-		out = dumbLoggerInstance
-	} else if logLevel.weight >= WARN.weight {
-		out = l.err
-	} else {
-		out = l.out
+	if !l.IsEnabled(logLevel) {
+		return
 	}
 
-	out.Printf(logFormat, objs...)
+	if out, ok := l.outputForLevel(logLevel); ok {
+		out.Printf(logFormat, objs...)
+		return
+	}
+
+	if logLevel.weight >= WARN.weight {
+		l.err.Printf(logFormat, objs...)
+		return
+	}
+
+	l.out.Printf(logFormat, objs...)
+}
+
+func (l logger) outputForLevel(logLevel LogLevel) (Output, bool) {
+	if l.router == nil {
+		return nil, false
+	}
+	return l.router.OutputFor(logLevel)
 }
 
 func (l logger) Debug(format string, objs ...interface{}) {


### PR DESCRIPTION
Add flexible writer management, dynamic log level control, and per-level output routing to glog. This allows custom output destinations and runtime verbosity changes without forking the library.

The existing `glog` library lacked mechanisms for advanced logging configurations, such as routing different log levels to distinct `io.Writer` implementations (e.g., for file rotation or separating debug logs) and changing the global log level dynamically during application execution. These changes address these limitations by providing new public APIs (`NewWithWriters`, `SetWriters`, `SetLevel`, `NewLevelRouter`, `SetOutputForLevel`) that enable greater control over logging behavior, making the library more adaptable to diverse operational requirements.

---
<a href="https://cursor.com/background-agent?bcId=bc-69125bbb-f5f7-48fa-a9a5-4d0b81b52fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-69125bbb-f5f7-48fa-a9a5-4d0b81b52fc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

